### PR TITLE
トップの説明の幅、配置位置を変更

### DIFF
--- a/mysite/static/css/base.css
+++ b/mysite/static/css/base.css
@@ -131,13 +131,16 @@ html, body {
     gap: -10px;
 }
 
-.header_wave .wave-box {
+.header_wave .wave-box,
+.footer_wave .wave-box
+ {
     width: 170px;
     height: 185px;
     background-color: #6AC15D;
     border-radius: 0 0 65px 65px; /* 下2つの角を丸くする */
     margin-left: -10px;
 }
+
 html, body {
     height: 100vh;
     margin: 0;
@@ -149,7 +152,6 @@ html, body {
 .footer {
     margin-top: auto;
     width: 100%;
-    background-color: #6AC15D;
     border-radius: 15px 15px 0px 0px;
     position: relative;
     padding: 0;
@@ -200,7 +202,7 @@ html, body {
 .guidelines_link {
     position: static;
     color: #FFFFFF;
-    font-size: 22px;
+    font-size: 20px;
     text-decoration: none;
 }
 
@@ -237,7 +239,7 @@ html, body {
 
 @media (max-width: 768px){
     .header_inner{
-    flex-direction:column;
+    flex-direction:row;
     height:auto;
     padding: 20px;
     gap: 20px;
@@ -271,6 +273,7 @@ html, body {
     .search-bar img,
     .create-button img,
     .login-button img {
+        display:block;
         width: 30px;
         height: 30px;
         object-fit: contain;
@@ -294,7 +297,7 @@ html, body {
 
     .footer_wave .wave-box {
     width: 80px;
-    height: 90px;
+    height: 180px;
     border-radius: 40px 40px 0 0;
     }
 

--- a/mysite/static/css/base.css
+++ b/mysite/static/css/base.css
@@ -305,4 +305,4 @@ html, body {
     font-size: 8px;
     bottom: 5px;
     }
-}
+}　

--- a/mysite/static/css/guidelines.css
+++ b/mysite/static/css/guidelines.css
@@ -23,8 +23,8 @@ h1 {
 /* Scrollとは */
 .summary {
     margin: 50px 100px auto 0; 
-    width: 1000px;
-    text-align: left;
+    width: 100%;
+    text-align: center;
     font-size: 20px;
 }
 

--- a/mysite/templates/base.html
+++ b/mysite/templates/base.html
@@ -6,6 +6,14 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>{% block title %}HAGAKUREプログラミング塾|Scroll{% endblock %}</title>
   <link rel="stylesheet" href="{% static 'css/base.css' %}">
+    <!-- Googleフォントを使用 -->
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Zen+Maru+Gothic:wght@400;500;700;900&display=swap"
+  rel="stylesheet">
+<!--  &lt;!&ndash; リセットCSSを使用 &ndash;&gt;-->
+<!--  <link rel="stylesheet" href="https://unpkg.com/ress/dist/ress.min.css">-->
+<!--  <link rel="stylesheet" href="{% static 'css/guidelines.css' %}">-->
 </head>
 <body>
 
@@ -19,6 +27,7 @@
       <div class="header-buttons">
         <a href="https://hagakurepgm.net/index.cgi/accounts/google/login/" class="login-button">
           <span class="button-text">記事を書く</span>
+          <img src="{% static 'image/base/create_icon.png' %}" alt="記事作成">
         </a>
       </div>
 

--- a/mysite/templates/base.html
+++ b/mysite/templates/base.html
@@ -13,7 +13,7 @@
   rel="stylesheet">
 <!--  &lt;!&ndash; リセットCSSを使用 &ndash;&gt;-->
 <!--  <link rel="stylesheet" href="https://unpkg.com/ress/dist/ress.min.css">-->
-<!--  <link rel="stylesheet" href="{% static 'css/guidelines.css' %}">-->
+<!--  <link rel="stylesheet" href="{% static 'css/guidelines.css' %}">-- >
 </head>
 <body>
 


### PR DESCRIPTION
▪️ガイドライン
・ガイドラインの説明文が、スマホサイズの時にはみ出す点を修正しました

※上野さんの修正きたらそちらに差し替えてください。とりあえずの修正しました〜
▪️全体
・base.htmにGoogleフォント追加しました
・フッターの緑背景削除しました
・スマホサイズの時にアイコン画像が表示されるようにしました
（とりあえず＋ボタンにしてます）

リセットCSS が入っていないので、設定したいのですが、
ページ番号の表示が崩れたのでやめました...そのうち修正が必要かと思います。