### PR TITLE
cssの微修正-2

### DIFF
--- a/blog/static/css/blog_index_page.css
+++ b/blog/static/css/blog_index_page.css
@@ -259,4 +259,9 @@ body {
   .page > a {
     padding: 6px;
   }
+  .summary
+  {
+    margin-top: 40px;
+    font-size: 0.7rem;
+  }
 }


### PR DESCRIPTION
blog_index_page.css　で、h2のサイズを追加で修正しました。
前回の修正と含めると、スマホのヘッダーと記事の枠（巻物）のサイズ感は↓↓に近づくはずですが、本番だとスマホのレイアウトがうまく反映できてないようです。

![IMG_5603](https://github.com/user-attachments/assets/73e45c76-c83a-4c59-a669-80022b51cfd6)
