### PR TITLE
feat: スラッグをID化＆スプレッドシートログ機能を追加

### DIFF
--- a/blog/signals.py
+++ b/blog/signals.py
@@ -3,12 +3,23 @@ from django.dispatch import receiver
 from blog.models import BlogPage
 from blog.utils.slack import send_slack_notification
 from blog.utils.openai_review import review_blog_content
+from blog.utils.sheet_logger import log_to_sheet
 
 @receiver(page_published)
 def notify_slack_on_publish(sender, instance, **kwargs):
     if isinstance(instance, BlogPage):
         # 本文を取得（例：page.bodyがStreamFieldの場合はstrで変換）
         content = str(instance.body)
+        
+        # 投稿者名を取得（owner または revision.user から）
+        author_name = "管理者"  # デフォルト値
+        if hasattr(instance, 'owner') and instance.owner:
+            author_name = instance.owner.get_full_name() or instance.owner.username
+        
+        # スプレッドシートにログ記録（重複チェックあり）
+        log_to_sheet(author_name, instance.title, content, instance.full_url)
+        
+        # Slackレビュー通知
         review = review_blog_content(content)
         text = (
             f"Scrollに新しい記事が公開されたでござる！\n"

--- a/blog/utils/sheet_logger.py
+++ b/blog/utils/sheet_logger.py
@@ -1,0 +1,101 @@
+import gspread
+import os
+import openai
+from google.oauth2.service_account import Credentials
+from pathlib import Path
+from datetime import datetime
+from dotenv import load_dotenv
+
+load_dotenv()
+openai.api_key = os.getenv("OPENAI_API_KEY")
+
+def generate_hagakure_summary(content):
+    """HAGAKURE君の口調で超簡潔に一言でブログ内容を説明"""
+    prompt = f"以下のブログ記事の内容を、超簡潔に一言（30文字以内）で説明してください。\n\n{content[:1000]}"  # 最初の1000文字のみ使用
+    
+    response = openai.chat.completions.create(
+        model="gpt-4o-mini",
+        messages=[
+            {"role": "system", "content": """ 
+あなたは「HAGAKURE君」という侍キャラクターです。
+・一人称は「拙者」
+・語尾には「ござる」が付く
+・「です」「ます」は使わない
+・超簡潔に一言（30文字以内）でブログの内容を説明する
+
+例：
+「Pythonの基礎を学ぶブログでござる」
+「Reactフックの使い方を解説しているでござる」
+「データベース設計の極意が書かれているでござる」
+         """},
+            {"role": "user", "content": prompt}
+        ],
+        max_tokens=100,
+        temperature=0.7,
+    )
+    return response.choices[0].message.content.strip()
+
+
+def log_to_sheet(author_name, post_title, content, post_url):
+    """
+    log_for_xシートにブログ投稿をログ記録
+    
+    Args:
+        author_name: 投稿者名
+        post_title: 投稿タイトル
+        content: ブログ本文
+        post_url: ブログのURL
+    
+    Returns:
+        bool: 記録に成功したか（重複の場合はFalse）
+    """
+    try:
+        # 認証情報を取得
+        BASE_DIR = Path(__file__).resolve().parent.parent.parent
+        SERVICE_ACCOUNT_FILE = os.path.join(BASE_DIR, 'mysite', 'settings', 'hagakurewagtailauth-fbf65e104bc8.json')
+        
+        creds = Credentials.from_service_account_file(
+            SERVICE_ACCOUNT_FILE,
+            scopes=["https://www.googleapis.com/auth/spreadsheets"]
+        )
+        
+        client = gspread.authorize(creds)
+        SPREADSHEET_ID = "1qW3HmauHOlqnAhaG-bsNx9I8Ank6Lan4h6uCU9tV0VQ"
+        spreadsheet = client.open_by_key(SPREADSHEET_ID)
+        
+        # log_for_xシートを取得
+        worksheet = spreadsheet.worksheet("log_for_x")
+        
+        # 既存データを取得（A列とB列）
+        all_records = worksheet.get_all_values()
+        
+        # 重複チェック：同じ投稿者名 + タイトルの組み合わせがあるか
+        for row in all_records:
+            if len(row) >= 2:
+                if row[0] == author_name and row[1] == post_title:
+                    print(f"重複：{author_name} - {post_title} はすでに記録されています")
+                    return False
+        
+        # 重複がない場合、HAGAKURE君の一言を生成
+        summary = generate_hagakure_summary(content)
+        
+        # 現在日時を取得
+        timestamp = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+        
+        # 新しい行を追加（A:投稿者, B:タイトル, C:一言, D:URL, E:日時）
+        new_row = [author_name, post_title, summary, post_url, timestamp]
+        worksheet.append_row(new_row)
+        
+        print(f"ログ記録成功：{author_name} - {post_title}")
+        return True
+        
+    except Exception as e:
+        print(f"シートへのログ記録エラー: {e}")
+        return False
+
+
+if __name__ == '__main__':
+    # テスト用
+    test_content = "Pythonの基礎について学びます。変数、関数、クラスなどの概念を解説します。"
+    log_to_sheet("テスト太郎", "Pythonの基礎", test_content, "https://example.com/blog/1")
+


### PR DESCRIPTION
## 概要
BlogPageのslugをレコードIDに自動設定し、スプレッドシートへの投稿ログ記録機能を実装しました。

## 主な変更点

### 1. スラッグのID化（blog/models.py）
- 新規作成時のみ、BlogPageの`slug`をレコードID（数値）に自動設定
- `url_path`も同時更新することで、BlogIndexPageからの遷移不整合を解消
- 既存記事の編集時はslugを変更しないため、URLが変わらない

### 2. スプレッドシートログ機能（blog/utils/sheet_logger.py）
`log_for_x`シートにブログ投稿情報を自動記録：
- **A列**: 投稿者名
- **B列**: 投稿タイトル  
- **C列**: HAGAKURE君の口調による一言説明（GPT-4o-miniで生成）
- **D列**: ブログURL
- **E列**: 投稿日時

#### 重複チェック機能
- 同一投稿者＋同一タイトルの組み合わせがすでに存在する場合はスキップ
- API呼び出しとシート記録の両方をスキップしてコスト削減

### 3. シグナル統合（blog/signals.py）
- ブログ公開時に投稿者情報を取得
- スプレッドシートログ機能を呼び出し

## テスト
- [ ] 新規ブログ作成時にslugがIDになることを確認
- [ ] スプレッドシートに正しくログが記録されることを確認
- [ ] 重複投稿時にスキップされることを確認

## 注意事項
- 既存記事の旧スラッグから新スラッグへのリダイレクトは、必要に応じて`wagtail.contrib.redirects`で設定してください
- GASとの併用も問題ありません